### PR TITLE
fix atomic 29 cgroup driver and kube-client pki owner group

### DIFF
--- a/roles/docker/tasks/atomic-29-fix.yml
+++ b/roles/docker/tasks/atomic-29-fix.yml
@@ -18,7 +18,7 @@
   replace:
     path:  /etc/systemd/system/docker.service
     regexp: 'native.cgroupdriver=\w+'
-    replace: "native.cgroupdriver={{docker_cgroup_driver}}"
+    replace: "native.cgroupdriver=cgroupfs"
   when: "ansible_distribution_major_version == '29'
       and 'kube_minions' in group_names"
   notify: restart docker

--- a/roles/kubectl/tasks/main.yml
+++ b/roles/kubectl/tasks/main.yml
@@ -10,7 +10,7 @@
   vars:
     pki_dest_dir: "{{kubectl_cert_folder}}"
     pki_dest_dir_owner: "{{ansible_user_id}}"
-    pki_dest_dir_group: "{{ansible_user_id}}"
+    pki_dest_dir_group: "{{ansible_user_gid}}"
     inventory_hostname: client
 
 - name: set kubectl context


### PR DESCRIPTION
fixes #15 